### PR TITLE
feat: add Node.js version checks with helpful error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ This project originated from a collection of custom CLI scripts and Firefox exte
 - No credentials stored in browser storage
 - See [docs/security/security-root.md](docs/security/security-root.md) for full details
 
+## Prerequisites
+
+**For Users (Quick Start):**
+- Firefox (latest version recommended)
+- No other dependencies required!
+
+**For Developers (Building from Source):**
+- **Node.js**: Version 22.14.0+ or 24.10.0+
+  - Check your version: `node --version`
+  - Install via [nvm](https://github.com/nvm-sh/nvm) or [nodejs.org](https://nodejs.org/)
+- **Yarn**: Package manager
+  - Install: `npm install -g yarn`
+- **Python 3.8+** (only for development mode with `--dev` flag)
+
+The version check runs automatically during installation and will provide clear instructions if your Node.js version needs updating.
+
 ## Installation
 
 ### Quick Start (No Python Required) ⚡

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,57 @@ if [ "$DEV_MODE" = true ]; then
     echo ""
 fi
 
+# Check Node.js version
+echo "Checking Node.js version..."
+if ! command -v node &> /dev/null; then
+    echo -e "${RED}Error: Node.js is not installed${NC}"
+    echo ""
+    echo "This project requires Node.js version 22.14.0 or later, or 24.10.0 or later."
+    echo ""
+    echo "Please install Node.js from:"
+    echo "  - https://nodejs.org/ (Official installer)"
+    echo "  - https://github.com/nvm-sh/nvm (Node Version Manager)"
+    echo ""
+    exit 1
+fi
+
+NODE_VERSION=$(node --version | sed 's/v//')
+NODE_MAJOR=$(echo $NODE_VERSION | cut -d. -f1)
+NODE_MINOR=$(echo $NODE_VERSION | cut -d. -f2)
+
+# Check if Node version meets requirements: ^22.14.0 || >= 24.10.0
+MEETS_REQUIREMENT=false
+
+if [ "$NODE_MAJOR" -eq 22 ] && [ "$NODE_MINOR" -ge 14 ]; then
+    MEETS_REQUIREMENT=true
+elif [ "$NODE_MAJOR" -eq 24 ] && [ "$NODE_MINOR" -ge 10 ]; then
+    MEETS_REQUIREMENT=true
+elif [ "$NODE_MAJOR" -gt 24 ]; then
+    MEETS_REQUIREMENT=true
+fi
+
+if [ "$MEETS_REQUIREMENT" = false ]; then
+    echo -e "${RED}Error: Node.js version $NODE_VERSION is not supported${NC}"
+    echo ""
+    echo "This project requires:"
+    echo "  - Node.js 22.14.0 or later (22.x branch)"
+    echo "  - Node.js 24.10.0 or later (24.x+ branch)"
+    echo ""
+    echo "You currently have: v$NODE_VERSION"
+    echo ""
+    echo "To upgrade Node.js:"
+    echo "  1. Using nvm (recommended):"
+    echo "     nvm install 24.10.0"
+    echo "     nvm use 24.10.0"
+    echo ""
+    echo "  2. Download from https://nodejs.org/"
+    echo ""
+    exit 1
+fi
+
+echo -e "${GREEN}✓${NC} Node.js v$NODE_VERSION"
+echo ""
+
 # Determine OS, platform, and architecture
 if [[ "$OSTYPE" == "darwin"* ]]; then
     OS="macos"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Firefox extension to open AWS profiles from credentials file in separate containers",
   "main": "index.js",
   "scripts": {
+    "preinstall": "node scripts/check-node-version.js",
     "build:transpile": "webpack --config config/webpack/webpack.prod.js",
     "build:update-version": "node scripts/build/update-version.js",
     "build:package": "web-ext build --source-dir ./dist/ --overwrite-dest",

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Check Node.js version compatibility
+ * Required: ^22.14.0 || >= 24.10.0
+ */
+
+const currentVersion = process.version.slice(1); // Remove 'v' prefix
+const [major, minor, patch] = currentVersion.split('.').map(Number);
+
+// Check if version meets requirements: ^22.14.0 || >= 24.10.0
+let meetsRequirement = false;
+
+if (major === 22 && minor >= 14) {
+    meetsRequirement = true;
+} else if (major === 24 && minor >= 10) {
+    meetsRequirement = true;
+} else if (major > 24) {
+    meetsRequirement = true;
+}
+
+if (!meetsRequirement) {
+    console.error('\x1b[31mError: Node.js version incompatible\x1b[0m');
+    console.error('');
+    console.error('This project requires:');
+    console.error('  - Node.js 22.14.0 or later (22.x branch)');
+    console.error('  - Node.js 24.10.0 or later (24.x+ branch)');
+    console.error('');
+    console.error(`You currently have: v${currentVersion}`);
+    console.error('');
+    console.error('To upgrade Node.js:');
+    console.error('  1. Using nvm (recommended):');
+    console.error('     nvm install 24.10.0');
+    console.error('     nvm use 24.10.0');
+    console.error('');
+    console.error('  2. Download from https://nodejs.org/');
+    console.error('');
+    process.exit(1);
+}
+
+console.log(`✓ Node.js v${currentVersion} - Compatible`);


### PR DESCRIPTION
**Problem:**
Users encounter cryptic errors when Node.js version is incompatible:
- semantic-release requires Node.js 22.14.0+ or 24.10.0+
- Current: v24.4.1 fails with unclear error message

**Solution:**
Added proactive version checks in two places:

1. **install.sh script:**
   - Checks Node.js version before running yarn commands
   - Validates: ^22.14.0 || >= 24.10.0
   - Provides clear error with upgrade instructions
   - Stops execution if version incompatible

2. **package.json preinstall hook:**
   - Runs automatically before yarn/npm install
   - Uses check-node-version.js script
   - Same validation and helpful error messages

**Error Message Includes:**
- Current version detected
- Required version ranges
- Upgrade instructions (nvm and direct download)
- Color-coded for visibility

**Files Added:**
- `scripts/check-node-version.js` - Standalone version checker

**Files Modified:**
- `install.sh` - Added version check before dependencies
- `package.json` - Added preinstall script hook
- `README.md` - Added Prerequisites section with version requirements

**Result:**
- Users get immediate, actionable feedback
- Clear instructions on how to upgrade Node.js
- Prevents confusing engine compatibility errors
- Works for both install.sh and direct yarn/npm install

## Summary by Sourcery

Validate Node.js version at install time to block unsupported versions and provide actionable, color-coded error messages with upgrade instructions

New Features:
- Add Node.js version check to install.sh preventing installation on unsupported Node versions
- Introduce check-node-version.js script and invoke it via package.json preinstall hook

Enhancements:
- Provide clear, color-coded error messages with current and required version details and upgrade instructions

Documentation:
- Update README.md Prerequisites section with Node.js version requirements and installation guidance